### PR TITLE
fix(dependency): Mirror github.com/tonymackay/go-yahoo-finance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+gamco-nav-check
 
 # Test binary, built with `go test -c`
 *.test

--- a/gamco-nav-check.go
+++ b/gamco-nav-check.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"math/big"
+	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/jidicula/go-gamco"
-	"github.com/tonymackay/go-yahoo-finance"
 )
 
 func main() {
@@ -51,7 +54,7 @@ func extractPrices(fl []gamco.Fund) (map[string]string, error) {
 	prices := make(map[string]string)
 	for _, v := range fl {
 		symbol := v.Symbol
-		result, err := yahoo.Quote(symbol)
+		result, err := Quote(symbol)
 		if err != nil {
 			return prices, err
 		}
@@ -162,4 +165,135 @@ func dumpOutput(sl []Stock, date time.Time) (string, error) {
 		return "", err
 	}
 	return path, err
+}
+
+const baseURL = "https://query2.finance.yahoo.com/v6/finance/quoteSummary/"
+
+// Quote returns stock price
+func Quote(symbol string) (QuoteResult, error) {
+	result := QuoteResult{}
+	quoteEndpoint := baseURL + strings.ToUpper(symbol) + "?modules=price"
+
+	resp, err := http.Get(quoteEndpoint)
+	if err != nil {
+		return result, err
+	}
+
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return result, readErr
+	}
+
+	jsonErr := json.Unmarshal(body, &result)
+	if jsonErr != nil {
+		return result, jsonErr
+	}
+
+	return result, nil
+}
+
+type QuoteResult struct {
+	QuoteSummary struct {
+		Result []struct {
+			Price struct {
+				MaxAge          int `json:"maxAge"`
+				PreMarketChange struct {
+				} `json:"preMarketChange"`
+				PreMarketPrice struct {
+				} `json:"preMarketPrice"`
+				PreMarketSource         string `json:"preMarketSource"`
+				PostMarketChangePercent struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"postMarketChangePercent"`
+				PostMarketChange struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"postMarketChange"`
+				PostMarketTime  int `json:"postMarketTime"`
+				PostMarketPrice struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"postMarketPrice"`
+				PostMarketSource           string `json:"postMarketSource"`
+				RegularMarketChangePercent struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketChangePercent"`
+				RegularMarketChange struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketChange"`
+				RegularMarketTime int `json:"regularMarketTime"`
+				PriceHint         struct {
+					Raw     int    `json:"raw"`
+					Fmt     string `json:"fmt"`
+					LongFmt string `json:"longFmt"`
+				} `json:"priceHint"`
+				RegularMarketPrice struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketPrice"`
+				RegularMarketDayHigh struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketDayHigh"`
+				RegularMarketDayLow struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketDayLow"`
+				RegularMarketVolume struct {
+					Raw     int    `json:"raw"`
+					Fmt     string `json:"fmt"`
+					LongFmt string `json:"longFmt"`
+				} `json:"regularMarketVolume"`
+				AverageDailyVolume10Day struct {
+				} `json:"averageDailyVolume10Day"`
+				AverageDailyVolume3Month struct {
+				} `json:"averageDailyVolume3Month"`
+				RegularMarketPreviousClose struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketPreviousClose"`
+				RegularMarketSource string `json:"regularMarketSource"`
+				RegularMarketOpen   struct {
+					Raw float64 `json:"raw"`
+					Fmt string  `json:"fmt"`
+				} `json:"regularMarketOpen"`
+				StrikePrice struct {
+				} `json:"strikePrice"`
+				OpenInterest struct {
+				} `json:"openInterest"`
+				Exchange              string      `json:"exchange"`
+				ExchangeName          string      `json:"exchangeName"`
+				ExchangeDataDelayedBy int         `json:"exchangeDataDelayedBy"`
+				MarketState           string      `json:"marketState"`
+				QuoteType             string      `json:"quoteType"`
+				Symbol                string      `json:"symbol"`
+				UnderlyingSymbol      interface{} `json:"underlyingSymbol"`
+				ShortName             string      `json:"shortName"`
+				LongName              string      `json:"longName"`
+				Currency              string      `json:"currency"`
+				QuoteSourceName       string      `json:"quoteSourceName"`
+				CurrencySymbol        string      `json:"currencySymbol"`
+				FromCurrency          interface{} `json:"fromCurrency"`
+				ToCurrency            interface{} `json:"toCurrency"`
+				LastMarket            interface{} `json:"lastMarket"`
+				Volume24Hr            struct {
+				} `json:"volume24Hr"`
+				VolumeAllCurrencies struct {
+				} `json:"volumeAllCurrencies"`
+				CirculatingSupply struct {
+				} `json:"circulatingSupply"`
+				MarketCap struct {
+					Raw     int64  `json:"raw"`
+					Fmt     string `json:"fmt"`
+					LongFmt string `json:"longFmt"`
+				} `json:"marketCap"`
+			} `json:"price"`
+		} `json:"result"`
+		Error interface{} `json:"error"`
+	} `json:"quoteSummary"`
 }


### PR DESCRIPTION
github.com/tonymackay/go-yahoo-finance seems to have disappeared, so this change copies out the implementation of `Quote()` and its dependents.

This change also downgrades the Yahoo Finance API endpoint from v10 to v6, since v10 is returning 401 now.